### PR TITLE
build: add docker file for GO implementation

### DIFF
--- a/Dockerfile-go
+++ b/Dockerfile-go
@@ -1,0 +1,13 @@
+FROM docker.io/golang:alpine AS builder
+
+WORKDIR /build
+
+COPY golang .
+
+RUN go build -o miner
+
+FROM scratch AS final
+
+COPY --from=builder /build/miner /miner
+
+ENTRYPOINT ["/miner"]


### PR DESCRIPTION
provides a minimal image with the go-binary.

I have not added any CI/CD stuff, as i don't know how you plan to release the images.
If you make changes to the CI/CD, can i suggest you push the images both as latest and with the short SHA as tag?
It will make it easier to version lock the image
